### PR TITLE
Fix poll and threads filtering

### DIFF
--- a/src/lib/Generic/CheckboxButtons.svelte
+++ b/src/lib/Generic/CheckboxButtons.svelte
@@ -8,11 +8,13 @@
 		Class = ""
 </script>
 
-<fieldset>
-	<h1 class="text-left text-sm">{$_(label)}</h1>
-	<div class={`mt-2 ${Class}`}>
+<fieldset class={Class}>
+	{#if label}
+		<h1 class="text-left text-sm">{$_(label)}</h1>
+	{/if}
+	<div class="flex items-center">
 		{#each labels as label}
-			<label class="mr-5 cursor-pointer" >
+			<label class="mr-5 cursor-pointer flex items-center gap-1" >
 				<input
 					type="checkbox"
 					name={label.label}

--- a/src/lib/Generic/CheckboxButtons.svelte
+++ b/src/lib/Generic/CheckboxButtons.svelte
@@ -16,7 +16,7 @@
 				<input
 					type="checkbox"
 					name={label.label}
-					value={label.checked}
+					checked={label.checked}
 					on:click={() => onChange(label.id)}
 					id={`input-${label.id}`}
 					class="cursor-pointer"

--- a/src/lib/Generic/Select.svelte
+++ b/src/lib/Generic/Select.svelte
@@ -25,10 +25,6 @@
 		bind:value
 		on:input={(e) => {
 			onInput(e);
-			//@ts-ignore
-			// if (e?.target?.value)
-			// 	//@ts-ignore
-			// 	value = e?.target?.value;
 		}}
 		class={`rounded p-1 dark:bg-darkobject ${classInner}`}
 		style="width:100%"

--- a/src/lib/Poll/PollFiltering.svelte
+++ b/src/lib/Poll/PollFiltering.svelte
@@ -10,6 +10,7 @@
 	import { homePolls as homePollsLimit } from '../Generic/APILimits.json';
 	import Select from '$lib/Generic/Select.svelte';
 	import CheckboxButtons from '$lib/Generic/CheckboxButtons.svelte';
+	import { browser } from '$app/environment';
 
 	export let filter: Filter,
 		handleSearch: () => {},
@@ -23,6 +24,20 @@
 	let searched = true,
 		tags: Tag[] = [];
 
+	// Initialize content type state from localStorage
+	const initializeContentTypeState = () => {
+		if (browser) {
+			const savedState = localStorage.getItem('contentTypeState');
+			if (savedState) {
+				const { threads, polls } = JSON.parse(savedState);
+				showThreads = threads;
+				showPolls = polls;
+				contentTypeLabels[0].checked = threads;
+				contentTypeLabels[1].checked = polls;
+			}
+		}
+	};
+
 	const contentTypeLabels = [
 		{ label: 'Threads', checked: true, id: 1 },
 		{ label: 'Polls', checked: true, id: 2 }
@@ -35,6 +50,14 @@
 		} else if (id === 2) {
 			showPolls = !showPolls;
 			contentTypeLabels[1].checked = showPolls;
+		}
+
+		// Save to localStorage
+		if (browser) {
+			localStorage.setItem('contentTypeState', JSON.stringify({
+				threads: showThreads,
+				polls: showPolls
+			}));
 		}
 	};
 
@@ -74,6 +97,7 @@
 
 	onMount(() => {
 		getTags();
+		initializeContentTypeState();
 	});
 
 	$: if (filter) handleSearch();
@@ -112,6 +136,7 @@
 			label=""
 			labels={contentTypeLabels}
 			onChange={handleContentTypeChange}
+			Class="flex items-center"
 		/>
 
 		<div class="rounded p-1">

--- a/src/lib/Poll/PollFiltering.svelte
+++ b/src/lib/Poll/PollFiltering.svelte
@@ -13,7 +13,7 @@
 	import { browser } from '$app/environment';
 
 	export let filter: Filter,
-		handleSearch: () => {},
+		handleSearch: () => void,
 		tagFiltering = false;
 	
 	// Add new export for content type filtering

--- a/src/lib/Poll/PollFiltering.svelte
+++ b/src/lib/Poll/PollFiltering.svelte
@@ -9,13 +9,34 @@
 	import type { Tag } from '$lib/Group/interface';
 	import { homePolls as homePollsLimit } from '../Generic/APILimits.json';
 	import Select from '$lib/Generic/Select.svelte';
+	import CheckboxButtons from '$lib/Generic/CheckboxButtons.svelte';
 
 	export let filter: Filter,
 		handleSearch: () => {},
 		tagFiltering = false;
+	
+	// Add new export for content type filtering
+	export let showThreads = true;
+	export let showPolls = true;
+
 	//Aesthethics only, changes the UI when searching would lead to different results.
 	let searched = true,
 		tags: Tag[] = [];
+
+	const contentTypeLabels = [
+		{ label: 'Threads', checked: true, id: 1 },
+		{ label: 'Polls', checked: true, id: 2 }
+	];
+
+	const handleContentTypeChange = (id: number) => {
+		if (id === 1) {
+			showThreads = !showThreads;
+			contentTypeLabels[0].checked = showThreads;
+		} else if (id === 2) {
+			showPolls = !showPolls;
+			contentTypeLabels[1].checked = showPolls;
+		}
+	};
 
 	const handleFinishedSelection = (e: any) => {
 		filter.finishedSelection = e.target.value;
@@ -76,7 +97,7 @@
 			bind:value={filter.search}
 		/>
 	</div>
-	<div class="flex gap-4">
+	<div class="flex gap-4 flex-wrap items-center">
 		<Select
 			Class="rounded p-1 flex flex-row items-center gap-1"
 			classInner="font-semibold border border-0"
@@ -87,45 +108,20 @@
 			bind:value={filter.order_by}
 		/>
 
-		<!-- <Select
-			Class="rounded p-1 flex flex-row items-center gap-1"
-			classInner="font-semibold border-0"
-			onInput={handleFinishedSelection}
-			values={['all', 'unfinished', 'finished']}
-			labels={[$_('All'), $_('Ongoing'), $_('Done')]}
-			label={$_('Status')}: 
-			bind:value={filter.finishedSelection}
+		<CheckboxButtons
+			label=""
+			labels={contentTypeLabels}
+			onChange={handleContentTypeChange}
 		/>
-
-		{#if tagFiltering}
-			<div class="rounded p-1 flex flex-row items-center gap-1">
-				<span>{$_('Work Group')}: </span>
-				<select
-					on:input={handleTags}
-					class="rounded p-1 border-0 font-semibold dark:border-gray-600 dark:bg-darkobject"
-				>
-					<option value={null}>{$_('All')}</option>
-					{#each tags as tag}
-						<option value={tag.id}>{elipsis(tag.name, 15)}</option>
-					{/each}
-				</select>
-			</div>
-		{/if} -->
 
 		<div class="rounded p-1">
-			<Button Class="!p-1 border-none text-red-600 cursor-pointer hover:underline" buttonStyle="warning-light" onClick={resetFilter}
-				>{$_('Reset Filter')}</Button
+			<Button 
+				Class="!p-1 border-none text-red-600 cursor-pointer hover:underline" 
+				buttonStyle="warning-light" 
+				onClick={resetFilter}
 			>
+				{$_('Reset Filter')}
+			</Button>
 		</div>
-
-		<!-- <CheckboxButtons
-			label={''}
-			labels={[
-				{ label: 'Finished', checked: false },
-				{ label: 'Not Finished', checked: false }
-			]}
-		/>
-	</div> -->
-		<!--<CheckboxButtons label={''} labels={[{label:'Public', checked:true}, {label:'Private', checked:true}]} /> -->
 	</div>
 </form>

--- a/src/lib/Poll/PollFiltering.svelte
+++ b/src/lib/Poll/PollFiltering.svelte
@@ -67,6 +67,7 @@
 
 	const handleSort = (e: any) => {
 		filter.order_by = e.target.value;
+		handleSearch();
 	};
 
 	const handleTags = (e: any) => {
@@ -112,8 +113,6 @@
 		getTags();
 		initializeContentTypeState();
 	});
-
-	$: if (filter) handleSearch();
 </script>
 
 <form

--- a/src/lib/Poll/PollFiltering.svelte
+++ b/src/lib/Poll/PollFiltering.svelte
@@ -93,6 +93,19 @@
 			order_by: 'start_date_desc',
 			tag: null
 		};
+		// Reset content type checkboxes
+		showThreads = true;
+		showPolls = true;
+		contentTypeLabels[0].checked = true;
+		contentTypeLabels[1].checked = true;
+		
+		// Update localStorage
+		if (browser) {
+			localStorage.setItem('contentTypeState', JSON.stringify({
+				threads: true,
+				polls: true
+			}));
+		}
 	};
 
 	onMount(() => {

--- a/src/lib/Poll/PollFiltering.svelte
+++ b/src/lib/Poll/PollFiltering.svelte
@@ -2,8 +2,6 @@
 	import TextInput from '$lib/Generic/TextInput.svelte';
 	import type { Filter } from './interface';
 	import { _ } from 'svelte-i18n';
-	import Fa from 'svelte-fa';
-	import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons/faMagnifyingGlass';
 	import Button from '$lib/Generic/Button.svelte';
 	import { fetchRequest } from '$lib/FetchRequest';
 	import { page } from '$app/stores';
@@ -11,7 +9,6 @@
 	import type { Tag } from '$lib/Group/interface';
 	import { homePolls as homePollsLimit } from '../Generic/APILimits.json';
 	import Select from '$lib/Generic/Select.svelte';
-	import { elipsis } from '$lib/Generic/GenericFunctions';
 
 	export let filter: Filter,
 		handleSearch: () => {},

--- a/src/lib/Poll/PollThreadThumbnails.svelte
+++ b/src/lib/Poll/PollThreadThumbnails.svelte
@@ -52,13 +52,7 @@
 	let showThreads = true;
 	let showPolls = true;
 
-	// Fetch related content on filter changes
-	$: if (filter) {
-		fetchPolls();
-		fetchRelatedContent();
-	}
-
-	// Add sorting reactive statement here
+	// Filters posts by updated_at date and filter.order_by.
 	$: {
 		if (posts.length) {
 			const sortedPosts = [...posts].sort((a, b) => {
@@ -151,7 +145,10 @@
 		<div class={`flex flex-col gap-6 w-full`}>
 			<PollFiltering
 				tagFiltering={infoToGet === 'group'}
-				handleSearch={fetchPolls}
+				handleSearch={() => {
+					fetchPolls();
+					fetchRelatedContent();
+				}}
 				bind:filter
 				bind:showThreads
 				bind:showPolls

--- a/src/lib/Poll/PollThreadThumbnails.svelte
+++ b/src/lib/Poll/PollThreadThumbnails.svelte
@@ -133,7 +133,6 @@
 		fetchRelatedContent();
 	}
 </script>
-bbbbb
 <div class={`${Class} dark:text-darkmodeText`}>
 	<Loader bind:loading>
 		<div class={`flex flex-col gap-6 w-full`}>
@@ -181,6 +180,5 @@ bbbbb
 		/>
 	</Loader>
 </div>
-aaaaaaa
 
 <Poppup bind:poppup />

--- a/src/lib/Poll/PollThreadThumbnails.svelte
+++ b/src/lib/Poll/PollThreadThumbnails.svelte
@@ -114,23 +114,21 @@
 		// Fetch polls
 		if (pollIds.length) {
 			const pollsUrl = infoToGet === 'home' 
-				? 'home/polls'
-				: `group/${$page.params.groupId}/poll/list?id_list=${pollIds.join(',')}`;
+				? `home/polls?order_by=${filter.order_by}`
+				: `group/${$page.params.groupId}/poll/list?id_list=${pollIds.join(',')}&order_by=${filter.order_by}`;
 			
 			const { json } = await fetchRequest('GET', pollsUrl);
 			polls = json.results;
-			console.log('Fetched polls:', polls);
 		}
 
 		// Fetch threads
 		if (threadIds.length) {
 			const threadsUrl = infoToGet === 'home'
-				? 'group/thread/list?group_ids=1,2,3,4'
-				: `group/thread/list?group_ids=${$page.params.groupId}&limit=1000&order_by=pinned,created_at_desc&id_list=${threadIds.join(',')}`;
+				? `group/thread/list?group_ids=1,2,3,4&order_by=${filter.order_by}`
+				: `group/thread/list?group_ids=${$page.params.groupId}&limit=1000&order_by=pinned,${filter.order_by}&id_list=${threadIds.join(',')}`;
 			
 			const { json } = await fetchRequest('GET', threadsUrl);
 			threads = json.results;
-			console.log('Fetched threads:', threads);
 		}
 	};
 
@@ -154,6 +152,12 @@
 			isAdmin = await getUserIsOwner($page.params.groupId) || false;
 		}
 	});
+
+	// Fetch related content on filter changes
+	$: if (filter) {
+		fetchPolls();
+		fetchRelatedContent();
+	}
 </script>
 
 <div class={`${Class} dark:text-darkmodeText`}>

--- a/src/lib/Poll/PollThreadThumbnails.svelte
+++ b/src/lib/Poll/PollThreadThumbnails.svelte
@@ -10,7 +10,6 @@
 	import type { poppup } from '$lib/Generic/Poppup';
 	import { getUserIsOwner } from '$lib/Group/functions';
 	import { env } from '$env/dynamic/public';
-	import { apiClient } from '$lib/api/client';
 	
 	import PollThumbnail from './PollThumbnail.svelte';
 	import PollFiltering from './PollFiltering.svelte';

--- a/src/lib/Poll/PollThreadThumbnails.svelte
+++ b/src/lib/Poll/PollThreadThumbnails.svelte
@@ -69,7 +69,7 @@
 				})
 			};
 
-			const response = await PollsApi.getPosts(infoToGet, params);
+			const response = await PollsApi.getPosts(infoToGet, params, delegate.pool_id);
 			posts = response.results;
 			next = response.next ?? '';
 			prev = response.previous ?? '';

--- a/src/lib/Poll/PollThreadThumbnails.svelte
+++ b/src/lib/Poll/PollThreadThumbnails.svelte
@@ -51,6 +51,29 @@
 	let showThreads = true;
 	let showPolls = true;
 
+	// Fetch related content on filter changes
+	$: if (filter) {
+		fetchPolls();
+		fetchRelatedContent();
+	}
+
+	// Add sorting reactive statement here
+	$: {
+		if (posts.length) {
+			const sortedPosts = [...posts].sort((a, b) => {
+				switch (filter.order_by) {
+					case 'start_date_desc':
+						return new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime();
+					case 'start_date_asc':
+						return new Date(a.updated_at).getTime() - new Date(b.updated_at).getTime();
+					default:
+						return 0;
+				}
+			});
+			posts = sortedPosts;
+		}
+	}
+
 	async function fetchPolls() {
 		try {
 			loading = true;
@@ -125,12 +148,6 @@
 			isAdmin = await getUserIsOwner($page.params.groupId) || false;
 		}
 	});
-
-	// Fetch related content on filter changes
-	$: if (filter) {
-		fetchPolls();
-		fetchRelatedContent();
-	}
 </script>
 <div class={`${Class} dark:text-darkmodeText`}>
 	<Loader bind:loading>

--- a/src/lib/Poll/PollThreadThumbnails.svelte
+++ b/src/lib/Poll/PollThreadThumbnails.svelte
@@ -52,7 +52,7 @@
 	let showThreads = true;
 	let showPolls = true;
 
-	// Filters posts by updated_at date and filter.order_by.
+	// Local sorting as fallback since server sorting isn't working correctly
 	$: {
 		if (posts.length) {
 			const sortedPosts = [...posts].sort((a, b) => {

--- a/src/lib/Poll/PollThreadThumbnails.svelte
+++ b/src/lib/Poll/PollThreadThumbnails.svelte
@@ -119,6 +119,7 @@
 			
 			const { json } = await fetchRequest('GET', pollsUrl);
 			polls = json.results;
+			console.log('Fetched polls:', polls);
 		}
 
 		// Fetch threads
@@ -129,6 +130,7 @@
 			
 			const { json } = await fetchRequest('GET', threadsUrl);
 			threads = json.results;
+			console.log('Fetched threads:', threads);
 		}
 	};
 

--- a/src/lib/Poll/PollThreadThumbnails.svelte
+++ b/src/lib/Poll/PollThreadThumbnails.svelte
@@ -47,6 +47,9 @@
 		tag: null
 	};
 
+	let showThreads = true;
+	let showPolls = true;
+
 	// API Helpers
 	const buildApiUrl = async () => {
 		const params = new URLSearchParams();
@@ -158,6 +161,8 @@
 				tagFiltering={infoToGet === 'group'}
 				handleSearch={fetchPolls}
 				bind:filter
+				bind:showThreads
+				bind:showPolls
 			/>
 			
 			{#if posts.length === 0 && !loading}
@@ -168,12 +173,12 @@
 				{#key posts}
 					{#if posts?.length > 0 && (polls.length > 0 || threads.length > 0)}
 						{#each posts as post}
-							{#if post.related_model === 'group_thread'}
+							{#if post.related_model === 'group_thread' && showThreads}
 								<ThreadThumbnail
 									{isAdmin}
 									thread={threads.find((thread) => thread.id === post.id) || threads[0]}
 								/>
-							{:else if post.related_model === 'poll'}
+							{:else if post.related_model === 'poll' && showPolls}
 								<PollThumbnail
 									poll={polls.find((poll) => poll.id === post.id) || polls[0]}
 									{isAdmin}

--- a/src/lib/Poll/PollThreadThumbnails.svelte
+++ b/src/lib/Poll/PollThreadThumbnails.svelte
@@ -10,6 +10,7 @@
 	import type { poppup } from '$lib/Generic/Poppup';
 	import { getUserIsOwner } from '$lib/Group/functions';
 	import { env } from '$env/dynamic/public';
+	import { ThreadsApi } from '$lib/api/threads';
 	
 	import PollThumbnail from './PollThumbnail.svelte';
 	import PollFiltering from './PollFiltering.svelte';
@@ -120,8 +121,8 @@
 
 		if (threadIds.length) {
 			const response = infoToGet === 'home'
-				? await PollsApi.getHomeThreads(filter.order_by)
-				: await PollsApi.getGroupThreads($page.params.groupId, threadIds, filter.order_by);
+				? await ThreadsApi.getHomeThreads(filter.order_by)
+				: await ThreadsApi.getGroupThreads($page.params.groupId, threadIds, filter.order_by);
 			threads = response.results;
 		}
 	}

--- a/src/lib/Poll/PollThreadThumbnails.svelte
+++ b/src/lib/Poll/PollThreadThumbnails.svelte
@@ -112,20 +112,16 @@
 			.map(post => post.id);
 
 		if (pollIds.length) {
-			const response = await PollsApi.getPolls(
-				infoToGet === 'home' ? null : $page.params.groupId,
-				pollIds,
-				filter.order_by
-			);
+			const response = infoToGet === 'home' 
+				? await PollsApi.getHomePolls(filter.order_by)
+				: await PollsApi.getGroupPolls($page.params.groupId, pollIds, filter.order_by);
 			polls = response.results;
 		}
 
 		if (threadIds.length) {
-			const response = await PollsApi.getThreads(
-				infoToGet === 'home' ? null : $page.params.groupId,
-				threadIds,
-				filter.order_by
-			);
+			const response = infoToGet === 'home'
+				? await PollsApi.getHomeThreads(filter.order_by)
+				: await PollsApi.getGroupThreads($page.params.groupId, threadIds, filter.order_by);
 			threads = response.results;
 		}
 	}

--- a/src/lib/Poll/PollThumbnail.svelte
+++ b/src/lib/Poll/PollThumbnail.svelte
@@ -84,7 +84,6 @@
 	};
 
 	onMount(async () => {
-		console.log('Poll object:', poll);
 		phase = getPhase(poll);
 		if (phase === 'area_vote') {
 			tags = await getTags(poll?.group_id);

--- a/src/lib/Poll/PollThumbnail.svelte
+++ b/src/lib/Poll/PollThumbnail.svelte
@@ -84,8 +84,7 @@
 	};
 
 	onMount(async () => {
-		// console.log(poll, phase, 'POLL AND PHASE');
-
+		console.log('Poll object:', poll);
 		phase = getPhase(poll);
 		if (phase === 'area_vote') {
 			tags = await getTags(poll?.group_id);
@@ -167,7 +166,7 @@
 				{/if}
 
 				<MultipleChoices
-					labels={phase === 'result' || phase === 'prediction_vote'
+					labels={phase === 'result' || phase === 'prediction_vote' || !poll?.allow_fast_forward
 						? [$_('Delete Poll')]
 						: [$_('Delete Poll'), $_('Fast Forward')]}
 					functions={[

--- a/src/lib/Poll/Thread.svelte
+++ b/src/lib/Poll/Thread.svelte
@@ -125,7 +125,7 @@
 		>
 			<a
 				class="text-black dark:text-darkmodeText flex justify-center gap-1"
-				href={`${thread?.created_by?.group_id}/thread/${thread?.id}`}
+				href={`groups/${thread?.created_by?.group_id}/thread/${thread?.id}`}
 			>
 				<img class="w-5" src={ChatIcon} alt="open chat" />
 				<span class="inline">{thread?.total_comments} {'comments'}</span>

--- a/src/lib/Poll/interface.ts
+++ b/src/lib/Poll/interface.ts
@@ -27,6 +27,7 @@ export interface poll {
 	attachments: { file: string }[];
 	allow_fast_forward: boolean;
 	created_by: number;
+	created_at: number;
 	description: string;
 	dynamic: boolean;
 	end_date: string;

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -1,0 +1,92 @@
+import { browser } from '$app/environment';
+import { goto } from '$app/navigation';
+import { env } from '$env/dynamic/public';
+
+type FetchOptions = {
+  method: string;
+  headers?: Record<string, string>;
+  body?: string | null;
+  needs_authorization?: boolean;
+  needs_json?: boolean;
+};
+
+export async function apiClient<T>(
+  endpoint: string, 
+  options: Partial<FetchOptions> = {}
+): Promise<T> {
+  const {
+    method = 'GET',
+    body = null,
+    needs_authorization = true,
+    needs_json = true,
+  } = options;
+
+  if (method === 'GET' && body !== null) {
+    console.warn("Method 'GET' does not take any body, use query parameters instead. For example: /api?id=5");
+  }
+
+  if (!browser) {
+    throw new Error('Cannot make API calls during SSR');
+  }
+
+  let headers: Record<string, string> = {};
+
+  // Handle authorization
+  if (needs_authorization) {
+    const token = localStorage.getItem('token');
+    const relativePath = new URL(location.href).pathname;
+
+    if (token) {
+      headers.Authorization = `Token ${token}`;
+    } else if (relativePath !== '/login') {
+      goto('/login');
+      throw new Error('Not authenticated');
+    }
+  }
+
+  // Handle JSON headers
+  if (needs_json) {
+    headers.Accept = 'application/json';
+    headers['Content-Type'] = 'application/json';
+  }
+
+  // Construct URL
+  const url = endpoint.includes(env.PUBLIC_API_URL)
+    ? endpoint
+    : `${env.PUBLIC_API_URL}/${env.PUBLIC_HAS_API === 'TRUE' ? 'api/' : ''}${endpoint}`;
+
+  // Prepare request options
+  const fetchOptions: RequestInit = {
+    method,
+    headers,
+  };
+
+  if (method !== 'GET' && body !== null) {
+    fetchOptions.body = needs_json ? JSON.stringify(body) : body;
+  }
+
+  const response = await fetch(url, fetchOptions);
+
+  // Handle 401 unauthorized
+  if (response.status === 401) {
+    const relativePath = new URL(location.href).pathname;
+    if (relativePath !== '/login') {
+      goto('/login');
+      throw new Error('Not authenticated');
+    }
+  }
+
+  // Handle response
+  try {
+    const data = await response.json();
+    if (!response.ok) {
+      throw new Error(data.detail || 'API call failed');
+    }
+    return data as T;
+  } catch (error) {
+    if (!response.ok) {
+      throw new Error('API call failed');
+    }
+    return {} as T;
+  }
+} 

--- a/src/lib/api/polls.ts
+++ b/src/lib/api/polls.ts
@@ -1,0 +1,72 @@
+import { apiClient } from './client';
+import type { ApiResponse, PollsParams } from './types';
+import type { poll, Post } from '$lib/Poll/interface';
+import type { Thread } from '$lib/Group/interface';
+import type { WorkGroup } from '$lib/Group/WorkingGroups/interface';
+
+export class PollsApi {
+  static async getPosts(infoToGet: string, params: PollsParams): Promise<ApiResponse<Post>> {
+    const baseUrl = this.getBaseUrl(infoToGet);
+    const queryParams = new URLSearchParams();
+    
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        queryParams.append(key, value.toString());
+      }
+    });
+
+    return apiClient<ApiResponse<Post>>(`${baseUrl}?${queryParams.toString()}`, {
+      method: 'GET',
+      needs_authorization: true,
+      needs_json: true
+    });
+  }
+
+  static async getPolls(groupId: string | null, pollIds: number[], orderBy: string): Promise<ApiResponse<poll>> {
+    const url = groupId
+      ? `group/${groupId}/poll/list?id_list=${pollIds.join(',')}&order_by=${orderBy}`
+      : `home/polls?order_by=${orderBy}`;
+    
+    return apiClient<ApiResponse<poll>>(url, {
+      method: 'GET',
+      needs_authorization: true,
+      needs_json: true
+    });
+  }
+
+  static async getThreads(groupId: string | null, threadIds: number[], orderBy: string): Promise<ApiResponse<Thread>> {
+    const url = groupId
+      ? `group/thread/list?group_ids=${groupId}&limit=1000&order_by=pinned,${orderBy}&id_list=${threadIds.join(',')}`
+      : `group/thread/list?group_ids=1,2,3,4&order_by=${orderBy}`;
+    
+    return apiClient<ApiResponse<Thread>>(url, {
+      method: 'GET',
+      needs_authorization: true,
+      needs_json: true
+    });
+  }
+
+  static async getWorkGroups(): Promise<ApiResponse<WorkGroup>> {
+    return apiClient<ApiResponse<WorkGroup>>('group/1/list', {
+      method: 'GET',
+      needs_authorization: true,
+      needs_json: true
+    });
+  }
+
+  private static getBaseUrl(infoToGet: string): string {
+    switch (infoToGet) {
+      case 'home':
+        return 'user/home';
+      case 'delegate':
+        return 'group/poll/pool';
+      case 'public':
+        return 'home/polls';
+      case 'user':
+      case 'group':
+        return 'user/home';
+      default:
+        throw new Error(`Unknown infoToGet: ${infoToGet}`);
+    }
+  }
+} 

--- a/src/lib/api/polls.ts
+++ b/src/lib/api/polls.ts
@@ -5,8 +5,8 @@ import type { Thread } from '$lib/Group/interface';
 import type { WorkGroup } from '$lib/Group/WorkingGroups/interface';
 
 export class PollsApi {
-  static async getPosts(infoToGet: string, params: PollsParams): Promise<ApiResponse<Post>> {
-    const baseUrl = this.getBaseUrl(infoToGet);
+  static async getPosts(infoToGet: string, params: PollsParams, delegatePoolId?: number): Promise<ApiResponse<Post>> {
+    const baseUrl = this.getBaseUrl(infoToGet, delegatePoolId);
     const queryParams = new URLSearchParams();
     
     Object.entries(params).forEach(([key, value]) => {
@@ -54,12 +54,13 @@ export class PollsApi {
     });
   }
 
-  private static getBaseUrl(infoToGet: string): string {
+  private static getBaseUrl(infoToGet: string, delegatePoolId?: number): string {
     switch (infoToGet) {
       case 'home':
         return 'user/home';
       case 'delegate':
-        return 'group/poll/pool';
+        if (!delegatePoolId) throw new Error('delegatePoolId is required for delegate view');
+        return `group/poll/pool/${delegatePoolId}/votes`;
       case 'public':
         return 'home/polls';
       case 'user':

--- a/src/lib/api/polls.ts
+++ b/src/lib/api/polls.ts
@@ -5,6 +5,9 @@ import type { Thread } from '$lib/Group/interface';
 import type { WorkGroup } from '$lib/Group/WorkingGroups/interface';
 
 export class PollsApi {
+  /**
+   * Fetches posts based on the view context (home, group, delegate etc)
+   */
   static async getPosts(infoToGet: string, params: PollsParams, delegatePoolId?: number): Promise<ApiResponse<Post>> {
     const baseUrl = this.getBaseUrl(infoToGet, delegatePoolId);
     const queryParams = new URLSearchParams();
@@ -15,43 +18,48 @@ export class PollsApi {
       }
     });
 
-    return apiClient<ApiResponse<Post>>(`${baseUrl}?${queryParams.toString()}`, {
-      method: 'GET',
-      requiresAuth: true,
-      jsonResponse: true,
-    });
+    return apiClient<ApiResponse<Post>>(`${baseUrl}?${queryParams.toString()}`);
   }
 
-  static async getPolls(groupId: string | null, pollIds: number[], orderBy: string): Promise<ApiResponse<poll>> {
-    const url = groupId
-      ? `group/${groupId}/poll/list?id_list=${pollIds.join(',')}&order_by=${orderBy}`
-      : `home/polls?order_by=${orderBy}`;
-    
-    return apiClient<ApiResponse<poll>>(url, {
-      method: 'GET',
-      requiresAuth: true,
-      jsonResponse: true,
-    });
+  /**
+   * Fetches polls for a specific group
+   */
+  static async getGroupPolls(groupId: string, pollIds: number[], orderBy: string): Promise<ApiResponse<poll>> {
+    return apiClient<ApiResponse<poll>>(
+      `group/${groupId}/poll/list?id_list=${pollIds.join(',')}&order_by=${orderBy}`
+    );
   }
 
-  static async getThreads(groupId: string | null, threadIds: number[], orderBy: string): Promise<ApiResponse<Thread>> {
-    const url = groupId
-      ? `group/thread/list?group_ids=${groupId}&limit=1000&order_by=pinned,${orderBy}&id_list=${threadIds.join(',')}`
-      : `group/thread/list?group_ids=1,2,3,4&order_by=${orderBy}`;
-    
-    return apiClient<ApiResponse<Thread>>(url, {
-      method: 'GET',
-      requiresAuth: true,
-      jsonResponse: true,
-    });
+  /**
+   * Fetches polls for the home feed (across all groups)
+   */
+  static async getHomePolls(orderBy: string): Promise<ApiResponse<poll>> {
+    return apiClient<ApiResponse<poll>>(`home/polls?order_by=${orderBy}`);
   }
 
+  /**
+   * Fetches threads for a specific group
+   */
+  static async getGroupThreads(groupId: string, threadIds: number[], orderBy: string): Promise<ApiResponse<Thread>> {
+    return apiClient<ApiResponse<Thread>>(
+      `group/thread/list?group_ids=${groupId}&limit=1000&order_by=pinned,${orderBy}&id_list=${threadIds.join(',')}`
+    );
+  }
+
+  /**
+   * Fetches threads across all groups (for home feed)
+   */
+  static async getHomeThreads(orderBy: string): Promise<ApiResponse<Thread>> {
+    return apiClient<ApiResponse<Thread>>(
+      `group/thread/list?group_ids=1,2,3,4&order_by=${orderBy}`
+    );
+  }
+
+  /**
+   * Fetches all available workgroups (Used only for "one group" flowback)
+   */
   static async getWorkGroups(): Promise<ApiResponse<WorkGroup>> {
-    return apiClient<ApiResponse<WorkGroup>>('group/1/list', {
-      method: 'GET',
-      requiresAuth: true,
-      jsonResponse: true,
-    });
+    return apiClient<ApiResponse<WorkGroup>>('group/1/list');
   }
 
   private static getBaseUrl(infoToGet: string, delegatePoolId?: number): string {

--- a/src/lib/api/polls.ts
+++ b/src/lib/api/polls.ts
@@ -17,8 +17,8 @@ export class PollsApi {
 
     return apiClient<ApiResponse<Post>>(`${baseUrl}?${queryParams.toString()}`, {
       method: 'GET',
-      needs_authorization: true,
-      needs_json: true
+      requiresAuth: true,
+      jsonResponse: true,
     });
   }
 
@@ -29,8 +29,8 @@ export class PollsApi {
     
     return apiClient<ApiResponse<poll>>(url, {
       method: 'GET',
-      needs_authorization: true,
-      needs_json: true
+      requiresAuth: true,
+      jsonResponse: true,
     });
   }
 
@@ -41,16 +41,16 @@ export class PollsApi {
     
     return apiClient<ApiResponse<Thread>>(url, {
       method: 'GET',
-      needs_authorization: true,
-      needs_json: true
+      requiresAuth: true,
+      jsonResponse: true,
     });
   }
 
   static async getWorkGroups(): Promise<ApiResponse<WorkGroup>> {
     return apiClient<ApiResponse<WorkGroup>>('group/1/list', {
       method: 'GET',
-      needs_authorization: true,
-      needs_json: true
+      requiresAuth: true,
+      jsonResponse: true,
     });
   }
 

--- a/src/lib/api/polls.ts
+++ b/src/lib/api/polls.ts
@@ -1,7 +1,6 @@
 import { apiClient } from './client';
 import type { ApiResponse, PollsParams } from './types';
 import type { poll, Post } from '$lib/Poll/interface';
-import type { Thread } from '$lib/Group/interface';
 import type { WorkGroup } from '$lib/Group/WorkingGroups/interface';
 
 export class PollsApi {
@@ -35,24 +34,6 @@ export class PollsApi {
    */
   static async getHomePolls(orderBy: string): Promise<ApiResponse<poll>> {
     return apiClient<ApiResponse<poll>>(`home/polls?order_by=${orderBy}`);
-  }
-
-  /**
-   * Fetches threads for a specific group
-   */
-  static async getGroupThreads(groupId: string, threadIds: number[], orderBy: string): Promise<ApiResponse<Thread>> {
-    return apiClient<ApiResponse<Thread>>(
-      `group/thread/list?group_ids=${groupId}&limit=1000&order_by=pinned,${orderBy}&id_list=${threadIds.join(',')}`
-    );
-  }
-
-  /**
-   * Fetches threads across all groups (for home feed)
-   */
-  static async getHomeThreads(orderBy: string): Promise<ApiResponse<Thread>> {
-    return apiClient<ApiResponse<Thread>>(
-      `group/thread/list?group_ids=1,2,3,4&order_by=${orderBy}`
-    );
   }
 
   /**

--- a/src/lib/api/threads.ts
+++ b/src/lib/api/threads.ts
@@ -1,0 +1,23 @@
+import { apiClient } from './client';
+import type { ApiResponse } from './types';
+import type { Thread } from '$lib/Group/interface';
+
+export class ThreadsApi {
+  /**
+   * Fetches threads for a specific group
+   */
+  static async getGroupThreads(groupId: string, threadIds: number[], orderBy: string): Promise<ApiResponse<Thread>> {
+    return apiClient<ApiResponse<Thread>>(
+      `group/thread/list?group_ids=${groupId}&limit=1000&order_by=pinned,${orderBy}&id_list=${threadIds.join(',')}`
+    );
+  }
+
+  /**
+   * Fetches threads across all groups (for home feed)
+   */
+  static async getHomeThreads(orderBy: string): Promise<ApiResponse<Thread>> {
+    return apiClient<ApiResponse<Thread>>(
+      `group/thread/list?group_ids=1,2,3,4&order_by=${orderBy}`
+    );
+  }
+} 

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -1,0 +1,16 @@
+export interface ApiResponse<T> {
+  results: T[];
+  next: string | null;
+  previous: string | null;
+}
+
+export interface PollsParams {
+  group_ids?: string;
+  order_by?: string;
+  limit?: number;
+  title__icontains?: string;
+  tag_id?: number;
+  end_date__lt?: string;
+  end_date__gt?: string;
+  public?: boolean;
+} 


### PR DESCRIPTION
@lokehagberg @Kattenelvis 
TASK: Det ska gå att filtrera och sortera flödet på senast-tidigast och poll-threads.

Jag har gjort så att man kan flitrera och att flödet sorteras. Dock, ger inte backend tillbaka datat sorterat. Jag har fixat så det filtrerar på frontend så länge. Tror inte "pinned" heller fungerar.

Detta är url som vi använder nu: http://127.0.0.1:8000/user/home?order_by=pinned%2Cstart_date_asc&limit=10
Vet inte om man ska använda något annat. Jag försökte med updated at och created at, men det fungerade inte heller.

<img width="986" alt="image" src="https://github.com/user-attachments/assets/a50ba0e6-e91a-469f-83d7-245a209c2648" />
